### PR TITLE
add avatar caching for unknown users

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ discord:
 
   # The delay in seconds between webhook sends (for maintaining message order).
   delay: 0.25
+
+  # The delay in seconds before a cached avatar is invalidated and refetched,
+  # in seconds. The default is 30 minutes.
+  avatar_cache: 1800
 ```
 
 ## Documentation

--- a/black_hole/discord.py
+++ b/black_hole/discord.py
@@ -34,13 +34,17 @@ class Discord:
     async def _get_from_cache(self, user_id: int) -> str:
         """Get an avatar in cache."""
 
-        # if we insert anything into the cache, this timestamp
+        # if we insert anything into the cache, invalidation_ts
         # represents when that value will become invalidated.
 
         # it uses time.monotonic() because the monotonic clock
         # is way more stable than the general clock.
         current = time.monotonic()
-        invalidation_ts = current + self.config['discord']['avatar_cache']
+
+        # the default is 30 minutes when not provided
+        cache_period = self.config['discord'].get('avatar_cache', 80 * 60)
+
+        invalidation_ts = current + cache_period
 
         value = self._avatar_cache.get(user_id)
 

--- a/black_hole/discord.py
+++ b/black_hole/discord.py
@@ -12,9 +12,6 @@ from .utils import clean_content
 
 log = logging.getLogger(__name__)
 
-#: period until a user in cache will be invalidated in seconds
-CACHE_INVALID = 30 * 60
-
 class Discord:
     """A wrapper around a Discord client that mirrors XMPP messages to a room's
     configured webhook.
@@ -42,7 +39,8 @@ class Discord:
 
         # it uses time.monotonic() because the monotonic clock
         # is way more stable than the general clock.
-        invalidation_ts = time.monotonic() + CACHE_INVALID
+        current = time.monotonic()
+        invalidation_ts = current + self.config['discord']['avatar_cache']
 
         value = self._avatar_cache.get(user_id)
 
@@ -63,7 +61,6 @@ class Discord:
             self._avatar_cache[user_id] = (invalidation_ts, avatar_url)
             return avatar_url
 
-        current = time.monotonic()
         user_ts, avatar_url = value
 
         # if the user cache value is invalid,


### PR DESCRIPTION
(pull request message taken from its single commit, which should
explain why we need this pr. if there are implementation questions,
feel free to ask)

it is possible for users to not share any guilds with
the bot. so we need to resort to something like get_user_info
but it has a low ratelimit. caching the avatar urls given
by get_user_info is a good strategy to circumventing it.

note: if the user already shares guilds with the bot, it won't
hit the cache at all.

the obvious downside is that avatar changes will take a while to
appear in the bot (considering the user still doesn't share any
guilds with it).

cache invalidation is set to 30 minutes, which should be a reasonable
default.

the cache is just a single dictionary because redis is way too much
for this kind of purpose.