### PR TITLE
handle short nicks

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ discord:
 
   # The delay in seconds between webhook sends (for maintaining message order).
   delay: 0.25
+
+  # The delay in seconds before a cached avatar is invalidated and refetched,
+  # in seconds. The default is 30 minutes.
+  avatar_cache: 1800
 ```
 
 ## Documentation

--- a/black_hole/discord.py
+++ b/black_hole/discord.py
@@ -109,6 +109,11 @@ class Discord:
         if len(content) > 1900:
             content = content[:1900] + '... (trimmed)'
 
+        # handle cases where the member's nick is too small for a
+        # webhook username
+        if len(nick) < 2:
+            nick = f'<{nick}>'
+
         payload = {
             'username': nick,
             'content': clean_content(content),

--- a/black_hole/discord.py
+++ b/black_hole/discord.py
@@ -34,13 +34,17 @@ class Discord:
     async def _get_from_cache(self, user_id: int) -> str:
         """Get an avatar in cache."""
 
-        # if we insert anything into the cache, this timestamp
+        # if we insert anything into the cache, invalidation_ts
         # represents when that value will become invalidated.
 
         # it uses time.monotonic() because the monotonic clock
         # is way more stable than the general clock.
         current = time.monotonic()
-        invalidation_ts = current + self.config['discord']['avatar_cache']
+
+        # the default is 30 minutes when not provided
+        cache_period = self.config['discord'].get('avatar_cache', 80 * 60)
+
+        invalidation_ts = current + cache_period
 
         value = self._avatar_cache.get(user_id)
 

--- a/black_hole/discord.py
+++ b/black_hole/discord.py
@@ -6,6 +6,7 @@ import time
 
 import aiohttp
 from discord.ext import commands
+from discord import DiscordException
 
 from .management import Management
 from .utils import clean_content
@@ -131,7 +132,7 @@ class Discord:
             try:
                 await self.session.post(job['webhook_url'], json=job['payload'])
                 await asyncio.sleep(self.config['discord'].get('delay', 0.25))
-            except (discord.DiscordException, aiohttp.ClientError):
+            except (DiscordException, aiohttp.ClientError):
                 log.exception('failed to bridge content')
         self._queue.clear()
         self._incoming.clear()

--- a/black_hole/discord.py
+++ b/black_hole/discord.py
@@ -12,9 +12,6 @@ from .utils import clean_content
 
 log = logging.getLogger(__name__)
 
-#: period until a user in cache will be invalidated in seconds
-CACHE_INVALID = 30 * 60
-
 class Discord:
     """A wrapper around a Discord client that mirrors XMPP messages to a room's
     configured webhook.
@@ -42,7 +39,8 @@ class Discord:
 
         # it uses time.monotonic() because the monotonic clock
         # is way more stable than the general clock.
-        invalidation_ts = time.monotonic() + CACHE_INVALID
+        current = time.monotonic()
+        invalidation_ts = current + self.config['discord']['avatar_cache']
 
         value = self._avatar_cache.get(user_id)
 
@@ -63,7 +61,6 @@ class Discord:
             self._avatar_cache[user_id] = (invalidation_ts, avatar_url)
             return avatar_url
 
-        current = time.monotonic()
         user_ts, avatar_url = value
 
         # if the user cache value is invalid,

--- a/black_hole/discord.py
+++ b/black_hole/discord.py
@@ -131,7 +131,7 @@ class Discord:
             try:
                 await self.session.post(job['webhook_url'], json=job['payload'])
                 await asyncio.sleep(self.config['discord'].get('delay', 0.25))
-            except aiohttp.ClientError:
+            except (discord.DiscordException, aiohttp.ClientError):
                 log.exception('failed to bridge content')
         self._queue.clear()
         self._incoming.clear()


### PR DESCRIPTION
due to a3.pm's common username strategy of just choosing a single letter that can cause errors when bridging messages back to discord. this pr also adds `DiscordException` to the discord bridge's exception catchers (it wasn't being catched before, and that caused debug troubles)