### PR TITLE
misc quality-of-life changes

### DIFF
--- a/black_hole/discord.py
+++ b/black_hole/discord.py
@@ -121,11 +121,21 @@ class Discord:
         if len(content) > 1900:
             content = content[:1900] + "... (trimmed)"
 
+        # handle cases where the member's nick is too small for a
+        # webhook username
+        if len(nick) < 2:
+            nick = f"<{nick}>"
+
+        avatar = await self.resolve_avatar(member)
+
         payload = {
             "username": ensure_valid_nick(member.nick),
             "content": clean_content(content),
             "avatar_url": await self.resolve_avatar(member),
         }
+
+        if avatar is not None:
+            payload["avatar_url"] = str(avatar)
 
         log.debug("adding message to queue")
 
@@ -156,9 +166,10 @@ class Discord:
                     body = "<none>"
 
                 log.warning(
-                    "failed to bridge discord -> xmpp. status=%d, body=%r",
+                    "failed to bridge discord -> xmpp. status=%d, body=%r, payload=%r",
                     resp.status,
                     body,
+                    job["payload"],
                 )
 
         self._queue.clear()

--- a/black_hole/discord.py
+++ b/black_hole/discord.py
@@ -121,21 +121,11 @@ class Discord:
         if len(content) > 1900:
             content = content[:1900] + "... (trimmed)"
 
-        # handle cases where the member's nick is too small for a
-        # webhook username
-        if len(nick) < 2:
-            nick = f"<{nick}>"
-
-        avatar = await self.resolve_avatar(member)
-
         payload = {
             "username": ensure_valid_nick(member.nick),
             "content": clean_content(content),
             "avatar_url": await self.resolve_avatar(member),
         }
-
-        if avatar is not None:
-            payload["avatar_url"] = str(avatar)
 
         log.debug("adding message to queue")
 


### PR DESCRIPTION
those came from updating my work, and i think it'd be good to bring the changes upstream

they're sadly all bundled up because i did not make them in separate branches and i had a bad time rebasing everything together.

- wrap calls in try/except so you have some output in the logs if they fail
- handle bad status codes when sending the message to the discord webhook (for the future: discord.py supports webhooks natively, including ratelimiting, might want to use it)
- a half-`black`-pass. i plan to create a separate pr that runs the formatter over the whole repo

those changes have been running on the elixire instance without issue. they're very handy